### PR TITLE
Fix: allow wchar in args under Windows; Feat: add ssingle file mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(HashUp VERSION 0.9.0 LANGUAGES CXX)
+project(HashUp VERSION 1.0.0 LANGUAGES CXX)
 
 # ============================================
 #                 build config

--- a/README.md
+++ b/README.md
@@ -54,8 +54,18 @@ That means:
 | `-w, --create` | Create a hash list for a directory | Cannot be used with `-r` |
 | `-r, --check` | Do hash check for a directory | Cannot be used with `-w` |
 | `-f, --file FILE` | Give the path of target hash list file, its parent path will be set as the root working directory | Mandatory argument |
+| `-s, --single` | Use single file mode | Should be used with `--hash` together when doing single file hash check |
+| `--hash HASH` | Give in file hash | Only available by single file hash check |
 | `-m, --mode MODE` | Set hash function (`md5`, `sha1`, `sha256`, `sha512`) | Default as `md5` |
 | `-j, --thread NUM` | Set the thread-number of multithreading acceleration | Default as `8` |
+
+### Single File Mode
+
+Single file mode is just like `curtutil -hashfile` under Windows and `md5sum`, `sha1sum`, etc. under Linux.
+
+You can use `-s, --single` argument to enable it.
+
+If you want to do single file hash check, you should give in the file hash with `--hash` argument.
 
 ### Examples
 
@@ -63,13 +73,13 @@ That means:
 hashup -w -f test.md5
 
 hashup -r -f ~/test/test.sha512 -m sha512 -j 16
+
+hashup -sw -f testfile -m md5
+
+hashup -sr -f testfile -m md5 --hash cdcc3d481ed7319c3fccec101126a75d
 ```
 
-## Known issues
-
-You can only give in an ASCII-Character only path with `-f, --file` under Windows.
-
-This problem is caused by wide-character encoding under Windows. The convert between UTF-8 and UTF-16LE and ANSI is a mess. I can only guarantee that HashUp can handle all filenames that can be saved under Windows (even if they contain unicode extension characters), but the problem above I really don't know how to solve it. If you know, feel free to PR.
+HashUp allows short arguments to be grouped after a hyphen. Actually arguments like `-srf testfile` is also okay, but I personally don't recommend it.
 
 ## Third Party Components
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -54,8 +54,18 @@ sudo make install
 | `-w, --create` | 进行哈希表生成 | 不能和 `-r` 连用 |
 | `-r, --check` | 进行哈希校验 | 不能和 `-w` 连用 |
 | `-f, --file` | 传入目标哈希表的路径，其父路径会被设为工作根路径 | 必须参数 |
+| `-s, --single` | 启用单文件模式 | 当进行单文件哈希校验时需要通过 `--hash` 开关传入哈希 |
+| `--hash HASH` | 传入文件哈希值 | 只在进行单文件哈希校验时可用 |
 | `-m, --mode MODE` | 设置哈希函数（`md5`，`sha1`，`sha256`，`sha512`）| 默认为 `md5` |
 | `-j, --thread NUM` | 设置多线程加速的线程数量 | 默认为 `8` |
+
+### 单文件模式
+
+单文件模式的功能和Windows下的 `certutil -hashfile` 和Linux下的 `md5sum`，`sha1sum` 等等的功能类似。
+
+你可以通过 `-s, --single` 开关启用单文件模式。
+
+如果你想进行单文件哈希校验，你应当通过 `--hash` 开关传入文件哈希值。
 
 ### 示例
 
@@ -63,13 +73,13 @@ sudo make install
 hashup -w -f test.md5
 
 hashup -r -f ~/test/test.sha512 -m sha512 -j 16
+
+hashup -sw -f testfile -m md5
+
+hashup -sr -f testfile -m md5 --hash cdcc3d481ed7319c3fccec101126a75d
 ```
 
-## 已知的问题
-
-在Windows下只能用 `-f, --file` 开关传入只包含ASCII字符的路径。
-
-这是由Windows下宽字符编码问题造成的。我只能保证HashUp可以处理所有Windows可以接受的文件名（即便他们包含unicode扩展字符）但我不知道怎么处理这里的命令行传入参数的编码转换问题。如果你知道应该怎么做并愿意告诉我，请提交PR。
+HashUp允许在一个中划线后同时传入多个短参数。其实类似于 `-srf testfile` 的传入方法也是合法的，但我个人不推荐这么做。
 
 ## 第三方组件
 

--- a/main.cpp
+++ b/main.cpp
@@ -27,10 +27,12 @@ int main( int argc , char** argv ){
 #endif
 
     int ret;
+    cmdline::parser cmdparser;
+    rena::HUFO hufo;
+    std::filesystem::path huf_path_get;
 
 #pragma region create_cmd_parser
 
-    cmdline::parser cmdparser;
     cmdparser.add                ( "help"    , '?'  , "Show this help page" );
     cmdparser.add                ( "create"  , 'w'  , "Create a hash list for a directory" );
     cmdparser.add                ( "check"   , 'r'  , "Do hash check for a directory" );
@@ -40,7 +42,6 @@ int main( int argc , char** argv ){
     cmdparser.add<std::string>   ( "mode"    , 'm'  , "Set hash mode (md5, sha1, sha256, sha512)"            , false , "md5" , cmdline::oneof<std::string>( "md5" , "sha1" , "sha256" , "sha512" ) );
     cmdparser.add<unsigned short>( "thread"  , 'j'  , "Set the thread-number of multithreading acceleration" , false , 8     , cmdline::range<unsigned short>( 1 , 128 ) );
     cmdparser.add                ( "version" , 'v'  , "Show HashUp version" );
-    cmdparser.add<std::string>( "test" , '\0' );
     cmdparser.set_program_name( "hashup" );
 
 #pragma endregion create_cmd_parser
@@ -96,7 +97,7 @@ int main( int argc , char** argv ){
             goto program_end;
         }
 
-        std::filesystem::path fp( cmdparser.get<std::string>( "file" ) );
+        std::filesystem::path fp( CPATOWCONV( cmdparser.get<std::string>( "file" ) ) );
         CPSTR hash;
         std::string mode = cmdparser.get<std::string>( "mode" );
         DEBUG_MSG( "Set Hash Mode: " << CPATOWCONV( mode ) );
@@ -145,9 +146,7 @@ int main( int argc , char** argv ){
         goto program_end;
     } // single file mode
 
-    rena::HUFO hufo;
-
-    std::filesystem::path huf_path_get = cmdparser.get<std::string>( "file" );
+    huf_path_get = CPATOWCONV( cmdparser.get<std::string>( "file" ) );
     if ( huf_path_get.is_relative() )
     {
         huf_path_get = std::filesystem::current_path() / huf_path_get;

--- a/main.cpp
+++ b/main.cpp
@@ -47,7 +47,7 @@ int main( int argc , char** argv ){
         } // show help page
         else
         {
-            CPOUT << "HashUp " << HASHUP_VERSION << " (branch/" << BUILD_GIT_BRANCH << ":" << BUILD_GIT_COMMIT << ", " << BUILD_TIME << ") [" << CXX_COMPILER_ID << " v." << CXX_COMPILER_VERSION << "] on " << BUILD_SYS_NAME << std::endl;
+            CPOUT << "HashUp " << HASHUP_VERSION << " (branch/" << BUILD_GIT_BRANCH << ":" << BUILD_GIT_COMMIT << ", " << BUILD_TIME << ") [" << CXX_COMPILER_ID << " " << CXX_COMPILER_VERSION << "] on " << BUILD_SYS_NAME << std::endl;
             return 0;
         } // show version
     } // arg error


### PR DESCRIPTION
# Ready to merge

Fixed problems:
- allow to give in unicode extension characters in program arguments under windows

New features:
- `--single` file mode, calc one file's hash and show / check it.